### PR TITLE
Fix eerors on ng build

### DIFF
--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -1,7 +1,12 @@
 import { Component } from '@angular/core';
+import { BokehChartComponent } from './shared/components/bokeh-chart/bokeh-chart.component';
 
 @Component({
   selector: 'app-root',
+  standalone: true,
+  imports: [
+    BokehChartComponent
+  ],
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css']
 })

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -8,13 +8,13 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 @NgModule({
   declarations: [
-    AppComponent
   ],
   imports: [
     BrowserModule,
     CoreModule,
     SharedModule,
-    BrowserAnimationsModule
+    BrowserAnimationsModule,
+    AppComponent
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/client/src/app/shared/components/bokeh-chart/bokeh-chart.component.ts
+++ b/client/src/app/shared/components/bokeh-chart/bokeh-chart.component.ts
@@ -3,6 +3,7 @@ import { BokehService } from './../../services/bokeh.service';
 
 @Component({
   selector: 'bokeh-chart',
+  standalone: true,
   templateUrl: './bokeh-chart.component.html',
   styleUrls: ['./bokeh-chart.component.css']
 })

--- a/client/src/app/shared/shared.module.ts
+++ b/client/src/app/shared/shared.module.ts
@@ -3,8 +3,6 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import {BrowserModule} from '@angular/platform-browser';
-import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 
 import { BokehChartComponent } from './components/bokeh-chart/bokeh-chart.component';
 
@@ -15,10 +13,10 @@ import { BokehChartComponent } from './components/bokeh-chart/bokeh-chart.compon
     FormsModule,
     ReactiveFormsModule,
     BrowserAnimationsModule,
+    BokehChartComponent,
   ],
   declarations: [
     // shared directives
-    BokehChartComponent
   ],
   exports: [
     // shared components
@@ -29,15 +27,6 @@ import { BokehChartComponent } from './components/bokeh-chart/bokeh-chart.compon
     BrowserAnimationsModule
   ],
   providers: [
-
-  ],
-  // With dynamically loaded components there are no selector references in the templates
-  // since components are loaded at runtime. In order to ensure that the compiler will still
-  // generate a factory, dynamically loaded components have to be added to their NgModule's
-  // entryComponents array.
-  // The dynamically loaded components woudln't be added due to the Treeshaking
-  // https://angular.io/docs/ts/latest/cookbook/dynamic-component-loader.html
-  entryComponents: [
 
   ],
   // bootstrap: [SandboxBottomSheetComponent]

--- a/python/tests/test_chart_provider.py
+++ b/python/tests/test_chart_provider.py
@@ -1,0 +1,16 @@
+import os
+import sys
+
+# Ensure services package can be imported
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+from services.chartProvider import ChartProvider
+
+
+def test_chart_provider_returns_bokeh_item():
+    cp = ChartProvider()
+    item = cp.chartExample()
+    assert isinstance(item, dict)
+    # Basic keys expected in a Bokeh JSON item
+    for key in ["target_id", "root_id", "doc", "version"]:
+        assert key in item


### PR DESCRIPTION
Notes

    Unit tests could not run because ChromeHeadless is missing, resulting in No binary for ChromeHeadless browser on your platform

Summary

    Declared the root component as standalone and imported the chart component so Angular 20 recognizes it

Updated AppModule to import the standalone AppComponent and removed unnecessary declarations

Converted BokehChartComponent to a standalone component for compatibility with modern Angular builds

Simplified SharedModule by importing and exporting the standalone component directly and removing deprecated entryComponents usage

Testing

    ✅ npx ng build

❌ npm test --silent (failed to find ChromeHeadless)

✅ npm run e2e --silent (no tests run)